### PR TITLE
Quick fix to Ethernet shields not starting.

### DIFF
--- a/examples/RF_Out_E131_In/RF_Out_E131_In.ino
+++ b/examples/RF_Out_E131_In/RF_Out_E131_In.ino
@@ -124,10 +124,26 @@ void setup(void)
   printf_begin();
 
   if(radio.Initialize(radio.TRANSMITTER, pipes, TRANSMIT_CHANNEL, DATA_RATE)){
-     Serial.print("Radio Is UP\n");
+     Serial.println("Radio Is UP");
   }else{
-     resetFunc(); //IF nrf failes reset 
+     resetFunc(); //If nrf failes reset 
   }
+  
+ 
+  //Convert the output from the ethernet lib to same format as ip array   
+  uint32_t value = Ethernet.localIP();
+  uint8_t ipFromEthernet[] = {value, value >> 8, value >> 16, value  >> 24};
+ //check of the hardware ip matches what shoudl have been set.
+  if((ipFromEthernet[0] == ip[0]) 
+  && (ipFromEthernet[1] == ip[1]) 
+  && (ipFromEthernet[2] == ip[2]) 
+  && (ipFromEthernet[3] == ip[3])){
+    Serial.println("Ethernet Is UP");
+  }else{
+	resetFunc(); //If nrf failes reset 
+  }
+  
+  
   delayMicroseconds(1500);
 
   radio.printDetails();

--- a/examples/RF_Out_E131_In/RF_Out_E131_In.ino
+++ b/examples/RF_Out_E131_In/RF_Out_E131_In.ino
@@ -105,6 +105,7 @@ uint8_t* validBuf;
 byte str[32];
 EthernetUDP Udp;
 
+void(* resetFunc) (void) = 0;//declare reset function at address 0
 
 bool validateRoot(uint8_t buf[]);
 bool validateDMP(uint8_t buf[]);

--- a/examples/RF_Out_E131_In/RF_Out_E131_In.ino
+++ b/examples/RF_Out_E131_In/RF_Out_E131_In.ino
@@ -124,6 +124,8 @@ void setup(void)
 
   if(radio.Initialize(radio.TRANSMITTER, pipes, TRANSMIT_CHANNEL, DATA_RATE)){
      Serial.print("Radio Is UP\n");
+  }else{
+     resetFunc(); //IF nrf failes reset 
   }
   delayMicroseconds(1500);
 

--- a/examples/RF_Out_E131_In/RF_Out_E131_In.ino
+++ b/examples/RF_Out_E131_In/RF_Out_E131_In.ino
@@ -122,7 +122,9 @@ void setup(void)
   Serial.println(F("\n[E1.31 Arduino Ethernet Transmitter ]\n"));
   printf_begin();
 
-  radio.Initialize(radio.TRANSMITTER, pipes, TRANSMIT_CHANNEL, DATA_RATE);
+  if(radio.Initialize(radio.TRANSMITTER, pipes, TRANSMIT_CHANNEL, DATA_RATE)){
+     Serial.print("Radio Is UP\n");
+  }
   delayMicroseconds(1500);
 
   radio.printDetails();


### PR DESCRIPTION
Check to see if ip was set on Ethernet shield, if not it reboots.

 I also added a reset to the nrf if it fails but it seams that radio.Initialize dosen't return anything but true when its in TX mode, I cant see a bug in the lib might want to figure that out later, its safe to merge anyways with that bug.

This fixes my iffy Ethernet shields see if it works for you guys.