### PR TITLE
Fix architecture and rainbow indices

### DIFF
--- a/MemoryFree.cpp
+++ b/MemoryFree.cpp
@@ -15,7 +15,7 @@ struct __freelist {
 /* The head of the free list structure */
 extern struct __freelist *__flp;
 
-#include "MemoryFree.h";
+#include "MemoryFree.h"
 
 /* Calculates the size of the free list */
 int freeListSize(void) {

--- a/examples/RF_Out_Rainbow_Test/RF_Out_Rainbow_Test.ino
+++ b/examples/RF_Out_Rainbow_Test/RF_Out_Rainbow_Test.ino
@@ -130,7 +130,7 @@ Modified by Greg scull to handle RF transmission.
 */
 void rainbow(int num)
 {
-	int i, j;
+	uint32_t i, j;
 
 	for (j = 0; j < 256; j++) // 3 cycles of all 256 colors in the wheel
 	{

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Wireless DMX Show control using nrf24l01
 paragraph=RFShowControl is awesome.  Visit http://learn.komby.com for more information
 category=Communication
 url=https://github.com/komby/RFShowControl
-architectures=AVR
+architectures=avr


### PR DESCRIPTION
This patch updates the architecture in library.properties so it works
with Arduino 1.6.12 and later.

Also changed the loop indicies in the rainbow() method to uint32 to fix overflow issues. and removed an extraneous semi-colon in MemoryFree.cpp
